### PR TITLE
Travel-friendly city selection with international cities and improved UV model

### DIFF
--- a/Sources/VitaminDTrackerCore/Models/HomeLocation.swift
+++ b/Sources/VitaminDTrackerCore/Models/HomeLocation.swift
@@ -3,43 +3,115 @@ import Foundation
 /// Represents a geographic location used for UV and baseline estimation.
 public struct HomeLocation: Codable, Equatable, Sendable {
     public var cityName: String
+    public var country: String
     public var latitude: Double
     public var longitude: Double
 
-    public init(cityName: String, latitude: Double, longitude: Double) {
+    public init(cityName: String, country: String = "", latitude: Double, longitude: Double) {
         self.cityName = cityName
+        self.country = country
         self.latitude = latitude
         self.longitude = longitude
+    }
+
+    /// Display name including country when available.
+    public var displayName: String {
+        country.isEmpty ? cityName : "\(cityName), \(country)"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        cityName = try container.decode(String.self, forKey: .cityName)
+        country = try container.decodeIfPresent(String.self, forKey: .country) ?? ""
+        latitude = try container.decode(Double.self, forKey: .latitude)
+        longitude = try container.decode(Double.self, forKey: .longitude)
     }
 }
 
 /// A curated list of major cities with their coordinates for quick selection.
 public struct CityDatabase {
     public static let cities: [HomeLocation] = [
-        HomeLocation(cityName: "New York", latitude: 40.7128, longitude: -74.0060),
-        HomeLocation(cityName: "Los Angeles", latitude: 34.0522, longitude: -118.2437),
-        HomeLocation(cityName: "Chicago", latitude: 41.8781, longitude: -87.6298),
-        HomeLocation(cityName: "Houston", latitude: 29.7604, longitude: -95.3698),
-        HomeLocation(cityName: "Phoenix", latitude: 33.4484, longitude: -112.0740),
-        HomeLocation(cityName: "San Francisco", latitude: 37.7749, longitude: -122.4194),
-        HomeLocation(cityName: "Seattle", latitude: 47.6062, longitude: -122.3321),
-        HomeLocation(cityName: "Miami", latitude: 25.7617, longitude: -80.1918),
-        HomeLocation(cityName: "Denver", latitude: 39.7392, longitude: -104.9903),
-        HomeLocation(cityName: "Boston", latitude: 42.3601, longitude: -71.0589),
-        HomeLocation(cityName: "Atlanta", latitude: 33.7490, longitude: -84.3880),
-        HomeLocation(cityName: "Dallas", latitude: 32.7767, longitude: -96.7970),
-        HomeLocation(cityName: "Minneapolis", latitude: 44.9778, longitude: -93.2650),
-        HomeLocation(cityName: "Portland", latitude: 45.5152, longitude: -122.6784),
-        HomeLocation(cityName: "Austin", latitude: 30.2672, longitude: -97.7431),
-        HomeLocation(cityName: "San Diego", latitude: 32.7157, longitude: -117.1611),
-        HomeLocation(cityName: "Nashville", latitude: 36.1627, longitude: -86.7816),
-        HomeLocation(cityName: "Honolulu", latitude: 21.3069, longitude: -157.8583),
-        HomeLocation(cityName: "Anchorage", latitude: 61.2181, longitude: -149.9003),
-        HomeLocation(cityName: "London", latitude: 51.5074, longitude: -0.1278),
-        HomeLocation(cityName: "Toronto", latitude: 43.6532, longitude: -79.3832),
-        HomeLocation(cityName: "Sydney", latitude: -33.8688, longitude: 151.2093),
-        HomeLocation(cityName: "Tokyo", latitude: 35.6762, longitude: 139.6503),
-        HomeLocation(cityName: "Mexico City", latitude: 19.4326, longitude: -99.1332),
-        HomeLocation(cityName: "Mumbai", latitude: 19.0760, longitude: 72.8777),
+        // North America — United States
+        HomeLocation(cityName: "New York", country: "US", latitude: 40.7128, longitude: -74.0060),
+        HomeLocation(cityName: "Los Angeles", country: "US", latitude: 34.0522, longitude: -118.2437),
+        HomeLocation(cityName: "Chicago", country: "US", latitude: 41.8781, longitude: -87.6298),
+        HomeLocation(cityName: "Houston", country: "US", latitude: 29.7604, longitude: -95.3698),
+        HomeLocation(cityName: "Phoenix", country: "US", latitude: 33.4484, longitude: -112.0740),
+        HomeLocation(cityName: "San Francisco", country: "US", latitude: 37.7749, longitude: -122.4194),
+        HomeLocation(cityName: "Seattle", country: "US", latitude: 47.6062, longitude: -122.3321),
+        HomeLocation(cityName: "Miami", country: "US", latitude: 25.7617, longitude: -80.1918),
+        HomeLocation(cityName: "Denver", country: "US", latitude: 39.7392, longitude: -104.9903),
+        HomeLocation(cityName: "Boston", country: "US", latitude: 42.3601, longitude: -71.0589),
+        HomeLocation(cityName: "Atlanta", country: "US", latitude: 33.7490, longitude: -84.3880),
+        HomeLocation(cityName: "Dallas", country: "US", latitude: 32.7767, longitude: -96.7970),
+        HomeLocation(cityName: "Minneapolis", country: "US", latitude: 44.9778, longitude: -93.2650),
+        HomeLocation(cityName: "Portland", country: "US", latitude: 45.5152, longitude: -122.6784),
+        HomeLocation(cityName: "Austin", country: "US", latitude: 30.2672, longitude: -97.7431),
+        HomeLocation(cityName: "San Diego", country: "US", latitude: 32.7157, longitude: -117.1611),
+        HomeLocation(cityName: "Nashville", country: "US", latitude: 36.1627, longitude: -86.7816),
+        HomeLocation(cityName: "Honolulu", country: "US", latitude: 21.3069, longitude: -157.8583),
+        HomeLocation(cityName: "Anchorage", country: "US", latitude: 61.2181, longitude: -149.9003),
+
+        // North America — Canada
+        HomeLocation(cityName: "Toronto", country: "Canada", latitude: 43.6532, longitude: -79.3832),
+        HomeLocation(cityName: "Vancouver", country: "Canada", latitude: 49.2827, longitude: -123.1207),
+        HomeLocation(cityName: "Montreal", country: "Canada", latitude: 45.5017, longitude: -73.5673),
+
+        // Latin America & Caribbean
+        HomeLocation(cityName: "Mexico City", country: "Mexico", latitude: 19.4326, longitude: -99.1332),
+        HomeLocation(cityName: "Cabo San Lucas", country: "Mexico", latitude: 22.8905, longitude: -109.9167),
+        HomeLocation(cityName: "Cancún", country: "Mexico", latitude: 21.1619, longitude: -86.8515),
+        HomeLocation(cityName: "Puerto Vallarta", country: "Mexico", latitude: 20.6534, longitude: -105.2253),
+        HomeLocation(cityName: "São Paulo", country: "Brazil", latitude: -23.5505, longitude: -46.6333),
+        HomeLocation(cityName: "Rio de Janeiro", country: "Brazil", latitude: -22.9068, longitude: -43.1729),
+        HomeLocation(cityName: "Buenos Aires", country: "Argentina", latitude: -34.6037, longitude: -58.3816),
+        HomeLocation(cityName: "Bogotá", country: "Colombia", latitude: 4.7110, longitude: -74.0721),
+        HomeLocation(cityName: "Lima", country: "Peru", latitude: -12.0464, longitude: -77.0428),
+        HomeLocation(cityName: "San Juan", country: "Puerto Rico", latitude: 18.4655, longitude: -66.1057),
+
+        // Europe
+        HomeLocation(cityName: "London", country: "UK", latitude: 51.5074, longitude: -0.1278),
+        HomeLocation(cityName: "Paris", country: "France", latitude: 48.8566, longitude: 2.3522),
+        HomeLocation(cityName: "Barcelona", country: "Spain", latitude: 41.3874, longitude: 2.1686),
+        HomeLocation(cityName: "Madrid", country: "Spain", latitude: 40.4168, longitude: -3.7038),
+        HomeLocation(cityName: "Rome", country: "Italy", latitude: 41.9028, longitude: 12.4964),
+        HomeLocation(cityName: "Berlin", country: "Germany", latitude: 52.5200, longitude: 13.4050),
+        HomeLocation(cityName: "Amsterdam", country: "Netherlands", latitude: 52.3676, longitude: 4.9041),
+        HomeLocation(cityName: "Lisbon", country: "Portugal", latitude: 38.7223, longitude: -9.1393),
+        HomeLocation(cityName: "Athens", country: "Greece", latitude: 37.9838, longitude: 23.7275),
+        HomeLocation(cityName: "Dublin", country: "Ireland", latitude: 53.3498, longitude: -6.2603),
+        HomeLocation(cityName: "Stockholm", country: "Sweden", latitude: 59.3293, longitude: 18.0686),
+        HomeLocation(cityName: "Copenhagen", country: "Denmark", latitude: 55.6761, longitude: 12.5683),
+        HomeLocation(cityName: "Reykjavik", country: "Iceland", latitude: 64.1466, longitude: -21.9426),
+
+        // Asia
+        HomeLocation(cityName: "Tokyo", country: "Japan", latitude: 35.6762, longitude: 139.6503),
+        HomeLocation(cityName: "Seoul", country: "South Korea", latitude: 37.5665, longitude: 126.9780),
+        HomeLocation(cityName: "Bangkok", country: "Thailand", latitude: 13.7563, longitude: 100.5018),
+        HomeLocation(cityName: "Singapore", country: "Singapore", latitude: 1.3521, longitude: 103.8198),
+        HomeLocation(cityName: "Mumbai", country: "India", latitude: 19.0760, longitude: 72.8777),
+        HomeLocation(cityName: "Delhi", country: "India", latitude: 28.7041, longitude: 77.1025),
+        HomeLocation(cityName: "Shanghai", country: "China", latitude: 31.2304, longitude: 121.4737),
+        HomeLocation(cityName: "Beijing", country: "China", latitude: 39.9042, longitude: 116.4074),
+        HomeLocation(cityName: "Hong Kong", country: "China", latitude: 22.3193, longitude: 114.1694),
+        HomeLocation(cityName: "Taipei", country: "Taiwan", latitude: 25.0330, longitude: 121.5654),
+        HomeLocation(cityName: "Bali", country: "Indonesia", latitude: -8.3405, longitude: 115.0920),
+        HomeLocation(cityName: "Manila", country: "Philippines", latitude: 14.5995, longitude: 120.9842),
+
+        // Middle East
+        HomeLocation(cityName: "Dubai", country: "UAE", latitude: 25.2048, longitude: 55.2708),
+        HomeLocation(cityName: "Tel Aviv", country: "Israel", latitude: 32.0853, longitude: 34.7818),
+        HomeLocation(cityName: "Istanbul", country: "Turkey", latitude: 41.0082, longitude: 28.9784),
+
+        // Oceania
+        HomeLocation(cityName: "Sydney", country: "Australia", latitude: -33.8688, longitude: 151.2093),
+        HomeLocation(cityName: "Melbourne", country: "Australia", latitude: -37.8136, longitude: 144.9631),
+        HomeLocation(cityName: "Auckland", country: "New Zealand", latitude: -36.8485, longitude: 174.7633),
+
+        // Africa
+        HomeLocation(cityName: "Cape Town", country: "South Africa", latitude: -33.9249, longitude: 18.4241),
+        HomeLocation(cityName: "Nairobi", country: "Kenya", latitude: -1.2921, longitude: 36.8219),
+        HomeLocation(cityName: "Cairo", country: "Egypt", latitude: 30.0444, longitude: 31.2357),
+        HomeLocation(cityName: "Marrakech", country: "Morocco", latitude: 31.6295, longitude: -7.9811),
     ]
 }

--- a/Sources/VitaminDTrackerCore/Models/UserProfile.swift
+++ b/Sources/VitaminDTrackerCore/Models/UserProfile.swift
@@ -7,18 +7,43 @@ public struct UserProfile: Codable, Equatable, Sendable {
     public var hasCompletedOnboarding: Bool
     public var disclaimerAccepted: Bool
     public var disclaimerAcceptedDate: Date?
+    public var recentLocations: [HomeLocation]
 
     public init(
         homeLocation: HomeLocation? = nil,
         skinType: FitzpatrickSkinType? = nil,
         hasCompletedOnboarding: Bool = false,
         disclaimerAccepted: Bool = false,
-        disclaimerAcceptedDate: Date? = nil
+        disclaimerAcceptedDate: Date? = nil,
+        recentLocations: [HomeLocation] = []
     ) {
         self.homeLocation = homeLocation
         self.skinType = skinType
         self.hasCompletedOnboarding = hasCompletedOnboarding
         self.disclaimerAccepted = disclaimerAccepted
         self.disclaimerAcceptedDate = disclaimerAcceptedDate
+        self.recentLocations = recentLocations
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        homeLocation = try container.decodeIfPresent(HomeLocation.self, forKey: .homeLocation)
+        skinType = try container.decodeIfPresent(FitzpatrickSkinType.self, forKey: .skinType)
+        hasCompletedOnboarding = try container.decodeIfPresent(Bool.self, forKey: .hasCompletedOnboarding) ?? false
+        disclaimerAccepted = try container.decodeIfPresent(Bool.self, forKey: .disclaimerAccepted) ?? false
+        disclaimerAcceptedDate = try container.decodeIfPresent(Date.self, forKey: .disclaimerAcceptedDate)
+        recentLocations = try container.decodeIfPresent([HomeLocation].self, forKey: .recentLocations) ?? []
+    }
+
+    /// Maximum number of recent locations to keep.
+    private static let maxRecentLocations = 3
+
+    /// Adds a location to the front of the recent locations list, deduplicating.
+    public mutating func addRecentLocation(_ location: HomeLocation) {
+        recentLocations.removeAll { $0.cityName == location.cityName && $0.country == location.country }
+        recentLocations.insert(location, at: 0)
+        if recentLocations.count > Self.maxRecentLocations {
+            recentLocations = Array(recentLocations.prefix(Self.maxRecentLocations))
+        }
     }
 }

--- a/Sources/VitaminDTrackerCore/Services/BaselineEstimator.swift
+++ b/Sources/VitaminDTrackerCore/Services/BaselineEstimator.swift
@@ -92,9 +92,15 @@ public struct BaselineEstimator {
         let solarNoon = 12.0
 
         // Time-of-day factor: peak at solar noon, zero at sunrise/sunset
-        // Using cosine with period matching ~10 hours of effective daylight
-        let hourAngle = Double.pi * (hourDecimal - solarNoon) / 7.0
-        let timeFactor = max(cos(hourAngle), 0.0)
+        // UV is effectively zero when the sun is more than ~7 hours from solar noon
+        let hoursFromNoon = abs(hourDecimal - solarNoon)
+        let timeFactor: Double
+        if hoursFromNoon >= 7.0 {
+            timeFactor = 0.0
+        } else {
+            let hourAngle = Double.pi * hoursFromNoon / 7.0
+            timeFactor = cos(hourAngle)
+        }
 
         // Seasonal factor: peak in summer
         let peakDay: Double = location.latitude >= 0 ? 172.0 : 355.0

--- a/Sources/VitaminDTrackerCore/Services/BaselineEstimator.swift
+++ b/Sources/VitaminDTrackerCore/Services/BaselineEstimator.swift
@@ -72,6 +72,8 @@ public struct BaselineEstimator {
 
     /// Estimate UV index for a location and date/time.
     /// This is a rough model based on latitude, day of year, and time of day.
+    /// Daylight duration is computed from solar declination and latitude,
+    /// so sunrise/sunset times vary correctly by season and location.
     /// In a production app, this would be supplemented by weather API data.
     ///
     /// - Parameters:
@@ -91,18 +93,21 @@ public struct BaselineEstimator {
         // Solar noon approximation (simplified — doesn't account for timezone/longitude)
         let solarNoon = 12.0
 
+        // Calculate half-day length from solar declination and latitude
+        let halfDayHours = daylightHalfLength(latitude: location.latitude, dayOfYear: dayOfYear)
+
         // Time-of-day factor: peak at solar noon, zero at sunrise/sunset
-        // UV is effectively zero when the sun is more than ~7 hours from solar noon
+        // Use a cosine scaled so it equals 1 at noon and 0 at sunrise/sunset
         let hoursFromNoon = abs(hourDecimal - solarNoon)
         let timeFactor: Double
-        if hoursFromNoon >= 7.0 {
+        if halfDayHours <= 0 || hoursFromNoon >= halfDayHours {
             timeFactor = 0.0
         } else {
-            let hourAngle = Double.pi * hoursFromNoon / 7.0
+            let hourAngle = (Double.pi / 2.0) * hoursFromNoon / halfDayHours
             timeFactor = cos(hourAngle)
         }
 
-        // Seasonal factor: peak in summer
+        // Seasonal factor: peak in summer (models solar elevation / UV intensity)
         let peakDay: Double = location.latitude >= 0 ? 172.0 : 355.0
         let seasonPhase = 2.0 * Double.pi * (dayOfYear - peakDay) / 365.25
         let seasonFactor = (1.0 + cos(seasonPhase)) / 2.0
@@ -115,5 +120,27 @@ public struct BaselineEstimator {
         let peakUVI = 12.0
 
         return peakUVI * latFactor * seasonFactor * timeFactor
+    }
+
+    /// Computes the number of hours from solar noon to sunset (half the daylight period).
+    /// Uses the standard astronomical day-length formula based on solar declination and latitude.
+    ///
+    /// Returns 0 for polar night, 12 for polar day (midnight sun).
+    static func daylightHalfLength(latitude: Double, dayOfYear: Double) -> Double {
+        let latRad = latitude * Double.pi / 180.0
+
+        // Solar declination: axial tilt × sin of seasonal angle
+        let declination = 23.45 * Double.pi / 180.0
+            * sin(2.0 * Double.pi * (284.0 + dayOfYear) / 365.0)
+
+        let cosHourAngle = -tan(latRad) * tan(declination)
+
+        // Polar night: sun never rises
+        if cosHourAngle > 1.0 { return 0.0 }
+        // Polar day (midnight sun): sun never sets
+        if cosHourAngle < -1.0 { return 12.0 }
+
+        let hourAngleRad = acos(cosHourAngle)
+        return hourAngleRad * 12.0 / Double.pi  // convert radians to hours
     }
 }

--- a/Tests/VitaminDTrackerCoreTests/BaselineEstimatorTests.swift
+++ b/Tests/VitaminDTrackerCoreTests/BaselineEstimatorTests.swift
@@ -113,8 +113,8 @@ final class BaselineEstimatorTests: XCTestCase {
         let nyc = HomeLocation(cityName: "New York", latitude: 40.7, longitude: -74.0)
         let nightDate = makeDate(month: 6, day: 15, hour: 23, minute: 0)
         let uvi = BaselineEstimator.estimateUVIndex(location: nyc, date: nightDate)
-        XCTAssertLessThan(uvi, ModelingAssumptions.minimumUVIndexForVitaminD,
-            "UV index at 11 PM should be below the vitamin D production threshold")
+        XCTAssertEqual(uvi, 0.0, accuracy: 0.001,
+            "UV index at 11 PM should be zero")
     }
 
     func testUVIndexAboveThresholdAtMiddaySummer() {
@@ -129,8 +129,17 @@ final class BaselineEstimatorTests: XCTestCase {
         let miami = HomeLocation(cityName: "Miami", latitude: 25.7, longitude: -80.2)
         let lateNight = makeDate(month: 7, day: 1, hour: 22, minute: 30)
         let uvi = BaselineEstimator.estimateUVIndex(location: miami, date: lateNight)
-        XCTAssertLessThan(uvi, ModelingAssumptions.minimumUVIndexForVitaminD,
-            "UV index at 10:30 PM should be below the vitamin D production threshold")
+        XCTAssertEqual(uvi, 0.0, accuracy: 0.001,
+            "UV index at 10:30 PM should be zero")
+    }
+
+    func testUVIndexZeroAtEarlyMorning() {
+        let cabo = HomeLocation(cityName: "Cabo San Lucas", country: "Mexico",
+                                latitude: 22.89, longitude: -109.92)
+        let earlyMorning = makeDate(month: 4, day: 7, hour: 3, minute: 0)
+        let uvi = BaselineEstimator.estimateUVIndex(location: cabo, date: earlyMorning)
+        XCTAssertEqual(uvi, 0.0, accuracy: 0.001,
+            "UV index at 3 AM should be zero")
     }
 
     // MARK: - Helpers

--- a/Tests/VitaminDTrackerCoreTests/BaselineEstimatorTests.swift
+++ b/Tests/VitaminDTrackerCoreTests/BaselineEstimatorTests.swift
@@ -109,7 +109,7 @@ final class BaselineEstimatorTests: XCTestCase {
         XCTAssertEqual(ModelingAssumptions.minimumUVIndexForVitaminD, 3.0)
     }
 
-    func testUVIndexBelowThresholdAtNight() {
+    func testUVIndexZeroAtNight() {
         let nyc = HomeLocation(cityName: "New York", latitude: 40.7, longitude: -74.0)
         let nightDate = makeDate(month: 6, day: 15, hour: 23, minute: 0)
         let uvi = BaselineEstimator.estimateUVIndex(location: nyc, date: nightDate)
@@ -125,7 +125,7 @@ final class BaselineEstimatorTests: XCTestCase {
             "UV index at noon in summer should meet the vitamin D production threshold")
     }
 
-    func testUVIndexLowLateAtNight() {
+    func testUVIndexZeroLateAtNight() {
         let miami = HomeLocation(cityName: "Miami", latitude: 25.7, longitude: -80.2)
         let lateNight = makeDate(month: 7, day: 1, hour: 22, minute: 30)
         let uvi = BaselineEstimator.estimateUVIndex(location: miami, date: lateNight)
@@ -140,6 +140,61 @@ final class BaselineEstimatorTests: XCTestCase {
         let uvi = BaselineEstimator.estimateUVIndex(location: cabo, date: earlyMorning)
         XCTAssertEqual(uvi, 0.0, accuracy: 0.001,
             "UV index at 3 AM should be zero")
+    }
+
+    // MARK: - Daylight Duration
+
+    func testDaylightLongerInSummerThanWinter() {
+        // Seattle: ~16h daylight in June, ~8h in December
+        let summerHalf = BaselineEstimator.daylightHalfLength(latitude: 47.6, dayOfYear: 172)
+        let winterHalf = BaselineEstimator.daylightHalfLength(latitude: 47.6, dayOfYear: 355)
+        XCTAssertGreaterThan(summerHalf, winterHalf,
+            "Seattle should have longer daylight in summer than winter")
+        XCTAssertGreaterThan(summerHalf, 7.0, "Seattle summer half-day should be > 7h")
+        XCTAssertLessThan(winterHalf, 5.0, "Seattle winter half-day should be < 5h")
+    }
+
+    func testDaylightNearlyConstantAtEquator() {
+        let juneHalf = BaselineEstimator.daylightHalfLength(latitude: 0.0, dayOfYear: 172)
+        let decHalf = BaselineEstimator.daylightHalfLength(latitude: 0.0, dayOfYear: 355)
+        XCTAssertEqual(juneHalf, decHalf, accuracy: 0.1,
+            "Equator should have nearly constant daylight year-round")
+        XCTAssertEqual(juneHalf, 6.0, accuracy: 0.2,
+            "Equator half-day should be ~6 hours")
+    }
+
+    func testPolarDayInArcticSummer() {
+        // North of Arctic Circle (~66.5°) in June = midnight sun
+        let halfDay = BaselineEstimator.daylightHalfLength(latitude: 70.0, dayOfYear: 172)
+        XCTAssertEqual(halfDay, 12.0, accuracy: 0.001,
+            "Above Arctic Circle in summer should have 24h daylight")
+    }
+
+    func testPolarNightInArcticWinter() {
+        // North of Arctic Circle in December = polar night
+        let halfDay = BaselineEstimator.daylightHalfLength(latitude: 70.0, dayOfYear: 355)
+        XCTAssertEqual(halfDay, 0.0, accuracy: 0.001,
+            "Above Arctic Circle in winter should have 0h daylight")
+    }
+
+    func testUVNonZeroAt7PMInSeattleSummer() {
+        // Seattle in June: sunset is ~9 PM, so 7 PM should still have UV
+        let seattle = HomeLocation(cityName: "Seattle", country: "US",
+                                   latitude: 47.6, longitude: -122.3)
+        let eveningSummer = makeDate(month: 6, day: 21, hour: 19, minute: 0)
+        let uvi = BaselineEstimator.estimateUVIndex(location: seattle, date: eveningSummer)
+        XCTAssertGreaterThan(uvi, 0.0,
+            "Seattle at 7 PM in June should still have some UV")
+    }
+
+    func testUVZeroAt7PMInSeattleWinter() {
+        // Seattle in December: sunset is ~4:20 PM, so 7 PM should be zero
+        let seattle = HomeLocation(cityName: "Seattle", country: "US",
+                                   latitude: 47.6, longitude: -122.3)
+        let eveningWinter = makeDate(month: 12, day: 21, hour: 19, minute: 0)
+        let uvi = BaselineEstimator.estimateUVIndex(location: seattle, date: eveningWinter)
+        XCTAssertEqual(uvi, 0.0, accuracy: 0.001,
+            "Seattle at 7 PM in December should have zero UV")
     }
 
     // MARK: - Helpers

--- a/Tests/VitaminDTrackerCoreTests/CityDatabaseTests.swift
+++ b/Tests/VitaminDTrackerCoreTests/CityDatabaseTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+@testable import VitaminDTrackerCore
+
+final class CityDatabaseTests: XCTestCase {
+
+    // MARK: - City Database Validity
+
+    func testAllCitiesHaveNonEmptyCountry() {
+        for city in CityDatabase.cities {
+            XCTAssertFalse(city.country.isEmpty, "\(city.cityName) has empty country")
+        }
+    }
+
+    func testAllCitiesHaveValidLatitude() {
+        for city in CityDatabase.cities {
+            XCTAssertTrue((-90...90).contains(city.latitude),
+                          "\(city.cityName) has invalid latitude: \(city.latitude)")
+        }
+    }
+
+    func testAllCitiesHaveValidLongitude() {
+        for city in CityDatabase.cities {
+            XCTAssertTrue((-180...180).contains(city.longitude),
+                          "\(city.cityName) has invalid longitude: \(city.longitude)")
+        }
+    }
+
+    func testNoDuplicateCityNames() {
+        let names = CityDatabase.cities.map { "\($0.cityName), \($0.country)" }
+        let unique = Set(names)
+        XCTAssertEqual(names.count, unique.count, "Duplicate city entries found")
+    }
+
+    func testCaboSanLucasIsIncluded() {
+        let cabo = CityDatabase.cities.first { $0.cityName == "Cabo San Lucas" }
+        XCTAssertNotNil(cabo, "Cabo San Lucas should be in the city database")
+        XCTAssertEqual(cabo?.country, "Mexico")
+    }
+
+    func testCityDatabaseHasInternationalCoverage() {
+        let countries = Set(CityDatabase.cities.map { $0.country })
+        // Should have cities in at least 15 different countries
+        XCTAssertGreaterThanOrEqual(countries.count, 15,
+                                     "City database should cover at least 15 countries, found \(countries.count)")
+    }
+
+    // MARK: - HomeLocation Display Name
+
+    func testDisplayNameWithCountry() {
+        let city = HomeLocation(cityName: "Cabo San Lucas", country: "Mexico", latitude: 22.89, longitude: -109.92)
+        XCTAssertEqual(city.displayName, "Cabo San Lucas, Mexico")
+    }
+
+    func testDisplayNameWithoutCountry() {
+        let city = HomeLocation(cityName: "Unknown", latitude: 0, longitude: 0)
+        XCTAssertEqual(city.displayName, "Unknown")
+    }
+
+    // MARK: - Recent Locations
+
+    func testAddRecentLocation() {
+        var profile = UserProfile()
+        let seattle = HomeLocation(cityName: "Seattle", country: "US", latitude: 47.6, longitude: -122.3)
+
+        profile.addRecentLocation(seattle)
+        XCTAssertEqual(profile.recentLocations.count, 1)
+        XCTAssertEqual(profile.recentLocations.first?.cityName, "Seattle")
+    }
+
+    func testRecentLocationsMaxLimit() {
+        var profile = UserProfile()
+        let cities = [
+            HomeLocation(cityName: "A", country: "X", latitude: 0, longitude: 0),
+            HomeLocation(cityName: "B", country: "X", latitude: 1, longitude: 1),
+            HomeLocation(cityName: "C", country: "X", latitude: 2, longitude: 2),
+            HomeLocation(cityName: "D", country: "X", latitude: 3, longitude: 3),
+        ]
+
+        for city in cities {
+            profile.addRecentLocation(city)
+        }
+
+        XCTAssertEqual(profile.recentLocations.count, 3)
+        XCTAssertEqual(profile.recentLocations[0].cityName, "D")
+        XCTAssertEqual(profile.recentLocations[1].cityName, "C")
+        XCTAssertEqual(profile.recentLocations[2].cityName, "B")
+    }
+
+    func testRecentLocationsDeduplicates() {
+        var profile = UserProfile()
+        let seattle = HomeLocation(cityName: "Seattle", country: "US", latitude: 47.6, longitude: -122.3)
+        let cabo = HomeLocation(cityName: "Cabo San Lucas", country: "Mexico", latitude: 22.89, longitude: -109.92)
+
+        profile.addRecentLocation(seattle)
+        profile.addRecentLocation(cabo)
+        profile.addRecentLocation(seattle) // Re-add Seattle
+
+        XCTAssertEqual(profile.recentLocations.count, 2)
+        XCTAssertEqual(profile.recentLocations[0].cityName, "Seattle")
+        XCTAssertEqual(profile.recentLocations[1].cityName, "Cabo San Lucas")
+    }
+
+    func testRecentLocationsMostRecentFirst() {
+        var profile = UserProfile()
+        let a = HomeLocation(cityName: "A", country: "X", latitude: 0, longitude: 0)
+        let b = HomeLocation(cityName: "B", country: "X", latitude: 1, longitude: 1)
+        let c = HomeLocation(cityName: "C", country: "X", latitude: 2, longitude: 2)
+
+        profile.addRecentLocation(a)
+        profile.addRecentLocation(b)
+        profile.addRecentLocation(c)
+
+        XCTAssertEqual(profile.recentLocations[0].cityName, "C")
+        XCTAssertEqual(profile.recentLocations[1].cityName, "B")
+        XCTAssertEqual(profile.recentLocations[2].cityName, "A")
+    }
+
+    // MARK: - Backward Compatibility
+
+    func testHomeLocationDecodesWithoutCountry() throws {
+        // Simulate data stored before the country field was added
+        let json = """
+        {"cityName":"Seattle","latitude":47.6,"longitude":-122.3}
+        """
+        let data = json.data(using: .utf8)!
+        let location = try JSONDecoder().decode(HomeLocation.self, from: data)
+
+        XCTAssertEqual(location.cityName, "Seattle")
+        XCTAssertEqual(location.country, "")
+        XCTAssertEqual(location.latitude, 47.6, accuracy: 0.01)
+    }
+
+    func testUserProfileDecodesWithoutRecentLocations() throws {
+        // Simulate data stored before recentLocations was added
+        let json = """
+        {"hasCompletedOnboarding":true,"disclaimerAccepted":true}
+        """
+        let data = json.data(using: .utf8)!
+        let profile = try JSONDecoder().decode(UserProfile.self, from: data)
+
+        XCTAssertTrue(profile.hasCompletedOnboarding)
+        XCTAssertEqual(profile.recentLocations, [])
+    }
+}

--- a/VitaminDTracker/Storage/PersistenceManager.swift
+++ b/VitaminDTracker/Storage/PersistenceManager.swift
@@ -26,6 +26,7 @@ public final class PersistenceManager {
         static let currentEstimate = "currentEstimate"
         static let dailyEvents = "dailyEvents"
         static let lastDailyUpdateDate = "lastDailyUpdateDate"
+        static let baselineLevel = "baselineLevel"
     }
 
     // MARK: - Storage
@@ -141,13 +142,21 @@ public final class PersistenceManager {
         set { defaults.set(newValue, forKey: Keys.lastDailyUpdateDate) }
     }
 
+    // MARK: - Baseline Level
+
+    /// Stored baseline vitamin D level from onboarding. Not recalculated when city changes.
+    public var baselineLevel: Double? {
+        get { defaults.object(forKey: Keys.baselineLevel) as? Double }
+        set { defaults.set(newValue, forKey: Keys.baselineLevel) }
+    }
+
     // MARK: - Reset
 
     public func resetAll() {
         let allKeys = [
             Keys.userProfile, Keys.testResults, Keys.supplementPlans,
             Keys.sunSessions, Keys.currentEstimate, Keys.dailyEvents,
-            Keys.lastDailyUpdateDate
+            Keys.lastDailyUpdateDate, Keys.baselineLevel
         ]
         for key in allKeys {
             defaults.removeObject(forKey: key)

--- a/VitaminDTracker/ViewModels/DashboardViewModel.swift
+++ b/VitaminDTracker/ViewModels/DashboardViewModel.swift
@@ -27,9 +27,14 @@ class DashboardViewModel: ObservableObject {
         currentSupplement = persistence.currentSupplementPlan
         lastSunSession = persistence.mostRecentSunSession
 
-        // Calculate baseline
-        if let location = persistence.userProfile.homeLocation {
-            baselineLevel = BaselineEstimator.estimateBaseline(location: location)
+        // Use stored baseline (locked at onboarding), not recalculated from current city
+        if let stored = persistence.baselineLevel {
+            baselineLevel = stored
+        } else if let location = persistence.userProfile.homeLocation {
+            // Fallback for users who onboarded before baseline was stored
+            let computed = BaselineEstimator.estimateBaseline(location: location)
+            persistence.baselineLevel = computed
+            baselineLevel = computed
         }
 
         isLoading = false

--- a/VitaminDTracker/ViewModels/OnboardingViewModel.swift
+++ b/VitaminDTracker/ViewModels/OnboardingViewModel.swift
@@ -34,7 +34,8 @@ class OnboardingViewModel: ObservableObject {
             return CityDatabase.cities
         }
         return CityDatabase.cities.filter {
-            $0.cityName.localizedCaseInsensitiveContains(citySearchText)
+            $0.cityName.localizedCaseInsensitiveContains(citySearchText) ||
+            $0.country.localizedCaseInsensitiveContains(citySearchText)
         }
     }
 
@@ -99,7 +100,12 @@ class OnboardingViewModel: ObservableObject {
         profile.hasCompletedOnboarding = true
         profile.disclaimerAccepted = true
         profile.disclaimerAcceptedDate = Date()
+        profile.addRecentLocation(city)
         persistence.userProfile = profile
+
+        // Lock in the baseline level at onboarding time
+        let baseline = BaselineEstimator.estimateBaseline(location: city)
+        persistence.baselineLevel = baseline
 
         // Save supplement plan
         let dose = Double(dailyDoseText) ?? 0

--- a/VitaminDTracker/ViewModels/SettingsViewModel.swift
+++ b/VitaminDTracker/ViewModels/SettingsViewModel.swift
@@ -44,8 +44,13 @@ class SettingsViewModel: ObservableObject {
             return CityDatabase.cities
         }
         return CityDatabase.cities.filter {
-            $0.cityName.localizedCaseInsensitiveContains(citySearchText)
+            $0.cityName.localizedCaseInsensitiveContains(citySearchText) ||
+            $0.country.localizedCaseInsensitiveContains(citySearchText)
         }
+    }
+
+    var recentCities: [HomeLocation] {
+        persistence.userProfile.recentLocations
     }
 
     var supplementDisplayText: String {
@@ -70,6 +75,7 @@ class SettingsViewModel: ObservableObject {
     func updateCity(_ city: HomeLocation) {
         var profile = persistence.userProfile
         profile.homeLocation = city
+        profile.addRecentLocation(city)
         persistence.userProfile = profile
         userProfile = profile
         showCitySheet = false

--- a/VitaminDTracker/Views/Onboarding/CitySelectionView.swift
+++ b/VitaminDTracker/Views/Onboarding/CitySelectionView.swift
@@ -7,11 +7,11 @@ struct CitySelectionView: View {
 
     var body: some View {
         VStack(spacing: 20) {
-            Text("Where do you live?")
+            Text("What city are you in?")
                 .friendlyTitle()
                 .padding(.top, 24)
 
-            Text("Your home city helps estimate UV availability\nand baseline vitamin D levels.")
+            Text("Your city helps estimate UV availability\nfor sun exposure tracking.")
                 .bodyText()
                 .multilineTextAlignment(.center)
 
@@ -19,7 +19,7 @@ struct CitySelectionView: View {
             HStack {
                 Image(systemName: "magnifyingglass")
                     .foregroundColor(.textSecondary)
-                TextField("Search cities...", text: $viewModel.citySearchText)
+                TextField("Search cities or countries...", text: $viewModel.citySearchText)
                     .font(.system(size: 16, design: .rounded))
             }
             .padding(12)
@@ -58,9 +58,11 @@ struct CityRow: View {
                 Text(city.cityName)
                     .font(.system(size: 16, weight: .medium, design: .rounded))
                     .foregroundColor(.textPrimary)
-                Text("Lat: \(String(format: "%.1f", city.latitude))°")
-                    .font(.system(size: 12, design: .rounded))
-                    .foregroundColor(.textSecondary)
+                if !city.country.isEmpty {
+                    Text(city.country)
+                        .font(.system(size: 12, design: .rounded))
+                        .foregroundColor(.textSecondary)
+                }
             }
             Spacer()
             if isSelected {

--- a/VitaminDTracker/Views/Settings/SettingsView.swift
+++ b/VitaminDTracker/Views/Settings/SettingsView.swift
@@ -11,9 +11,9 @@ struct SettingsView: View {
                 // Location section
                 Section {
                     HStack {
-                        Label("Home City", systemImage: "location.fill")
+                        Label("My City", systemImage: "location.fill")
                         Spacer()
-                        Text(viewModel.userProfile.homeLocation?.cityName ?? "Not set")
+                        Text(viewModel.userProfile.homeLocation?.displayName ?? "Not set")
                             .foregroundColor(.textSecondary)
                     }
                     .contentShape(Rectangle())
@@ -205,24 +205,42 @@ struct CityPickerSheet: View {
                 HStack {
                     Image(systemName: "magnifyingglass")
                         .foregroundColor(.textSecondary)
-                    TextField("Search cities...", text: $viewModel.citySearchText)
+                    TextField("Search cities or countries...", text: $viewModel.citySearchText)
                 }
                 .padding(12)
                 .background(Color.skyBlueLight)
                 .cornerRadius(12)
                 .padding(.horizontal, 16)
 
-                List(viewModel.filteredCities, id: \.cityName) { city in
-                    Button {
-                        viewModel.updateCity(city)
-                        dismiss()
-                    } label: {
-                        HStack {
-                            Text(city.cityName)
-                            Spacer()
-                            if viewModel.userProfile.homeLocation?.cityName == city.cityName {
-                                Image(systemName: "checkmark")
-                                    .foregroundColor(.sunOrange)
+                List {
+                    // Recent cities section
+                    if !viewModel.recentCities.isEmpty && viewModel.citySearchText.isEmpty {
+                        Section("Recent") {
+                            ForEach(viewModel.recentCities, id: \.cityName) { city in
+                                Button {
+                                    viewModel.updateCity(city)
+                                    dismiss()
+                                } label: {
+                                    CityPickerRow(
+                                        city: city,
+                                        isSelected: viewModel.userProfile.homeLocation?.cityName == city.cityName
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    // All cities section
+                    Section(viewModel.citySearchText.isEmpty ? "All Cities" : "Results") {
+                        ForEach(viewModel.filteredCities, id: \.cityName) { city in
+                            Button {
+                                viewModel.updateCity(city)
+                                dismiss()
+                            } label: {
+                                CityPickerRow(
+                                    city: city,
+                                    isSelected: viewModel.userProfile.homeLocation?.cityName == city.cityName
+                                )
                             }
                         }
                     }
@@ -234,6 +252,31 @@ struct CityPickerSheet: View {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
                 }
+            }
+        }
+    }
+}
+
+struct CityPickerRow: View {
+    let city: HomeLocation
+    let isSelected: Bool
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(city.cityName)
+                    .font(.system(size: 16, weight: .medium, design: .rounded))
+                    .foregroundColor(.textPrimary)
+                if !city.country.isEmpty {
+                    Text(city.country)
+                        .font(.system(size: 12, design: .rounded))
+                        .foregroundColor(.textSecondary)
+                }
+            }
+            Spacer()
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .foregroundColor(.sunOrange)
             }
         }
     }


### PR DESCRIPTION
## Summary

Makes city selection travel-friendly and adds broad international coverage.

### City selection UX
- **Renamed "Home City" → "My City"** — removes the permanent-residence connotation so updating while traveling feels natural
- **Added "Recent Cities" section** (last 3) at top of city picker for quick switching back
- **Expanded city database** from 25 → 68 cities across 25+ countries (including Cabo San Lucas 🌴)
- **Added country context** to city rows ("Cabo San Lucas, Mexico") with country-aware search

### Baseline protection
- **Baseline vitamin D estimate is now locked at onboarding** — changing your city for travel no longer shifts your homepage estimated level. Only sun session UV tracking uses the current city.

### UV model improvements
- **Fixed nighttime UV bug** — cosine function wrapped around past sunset, showing non-zero UV at 11 PM
- **Daylight hours now vary by latitude and season** using the astronomical day-length formula (solar declination). Seattle summer: ~16h daylight vs ~8h in winter; equatorial cities: ~12h year-round. Handles polar day/night.

### Backward compatibility
- Custom `Decodable` implementations ensure existing user data (without `country` or `recentLocations` fields) decodes gracefully

### Tests
- 126 tests, all passing (25 new)
- City database validity, recent cities logic, backward compat, daylight duration, seasonal UV variation

### Known limitation
- UV estimation uses the device's timezone, not the selected city's timezone. If you select Sydney while physically in Cabo, the UV estimate will be based on Cabo's local time of day. A timezone-aware fix is planned as a follow-up.