### PR TITLE
docs: fix latitude table to match clamped code value at equator

### DIFF
--- a/MODELING.md
+++ b/MODELING.md
@@ -66,10 +66,12 @@ Clamped to [-12, +8] ng/mL
 
 | Latitude | Adjustment |
 |----------|-----------|
-| 0° (equator) | +10 ng/mL |
+| 0° (equator) | +8 ng/mL (raw +9.99, capped by the +8 clamp) |
 | 30° | 0 ng/mL |
 | 45° | -5 ng/mL |
 | 60° | -10 ng/mL |
+
+Note: the raw formula yields +9.99 ng/mL at the equator, but the `[-12, +8]` clamp caps the applied value at +8 ng/mL.
 
 **Sources:**
 - Kimlin MG. Geographic location and vitamin D synthesis. *Mol Aspects Med.* 2008;29(6):453-461.


### PR DESCRIPTION
## Summary
`MODELING.md` §3.2 listed **+10 ng/mL** as the latitude adjustment at the equator, but `BaselineEstimator.latitudeEffect` clamps the result to `[-12, +8]`. The raw formula gives +9.99 at the equator, which the clamp caps at **+8**. The doc even states that clamp on the line directly above the table, so it contradicted itself as well as the code.

## Change
- Update the equator row to +8 ng/mL.
- Add a note explaining the raw value is capped by the clamp.

Doc-only change; no code or tests affected.